### PR TITLE
Create PrompVerse prompt manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+npm-debug.log*

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,19 @@
+# PrompVerse
 
+Aplicación web ligera para gestionar colecciones de prompts temáticos de Inteligencia Artificial. Permite organizar los prompts en grupos, editarlos como si fueran una conversación tipo chat y guarda automáticamente cada cambio en el navegador.
+
+## Características principales
+
+- 📂 Agrupa prompts por temática y accede rápidamente a cada uno desde la barra lateral.
+- 💬 Estructura cada prompt como un flujo de mensajes (sistema, usuario, asistente) editable.
+- 💾 Guardado automático en `localStorage` tras cada modificación.
+- 🎨 Interfaz oscura, moderna y responsiva, inspirada en paneles profesionales.
+
+## Uso
+
+1. Abre el archivo `index.html` en tu navegador preferido.
+2. Crea nuevos grupos o trabaja con los ejemplos cargados por defecto.
+3. Añade, edita o elimina mensajes dentro de cada conversación temática.
+4. Los cambios se guardan al instante en tu navegador, por lo que al volver tendrás tu información lista.
+
+> **Nota:** PrompVerse no requiere dependencias ni procesos de build. Todo el comportamiento ocurre en el navegador.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PrompVerse</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="app" class="app-container">
+      <div class="loading-state">Cargando PrompVerse...</div>
+    </div>
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "prompverse",
+  "version": "1.0.0",
+  "description": "Gestor visual de prompts temáticos para IA",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No hay pruebas automatizadas\" && exit 0"
+  },
+  "keywords": ["prompts", "ia", "productividad"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,602 @@
+const STORAGE_KEY = 'prompverse::workspace';
+const SAVE_DELAY = 700;
+
+let appState;
+const refs = {};
+let saveTimeout = null;
+
+const ROLE_LABELS = {
+  system: 'Sistema',
+  user: 'Usuario',
+  assistant: 'Asistente',
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  appState = loadInitialState();
+  buildLayout();
+  renderSidebar();
+  renderChat();
+  updateSaveIndicator('saved');
+  updateLastSavedDisplay();
+});
+
+function buildLayout() {
+  const app = document.getElementById('app');
+  app.innerHTML = `
+    <div class="dashboard">
+      <aside class="sidebar">
+        <div class="sidebar__header">
+          <h1 class="sidebar__title">PrompVerse</h1>
+          <p class="sidebar__subtitle">Gestiona, refina y organiza tus prompts temáticos.</p>
+        </div>
+        <div class="sidebar__actions">
+          <button class="button button--primary" type="button" data-action="add-group">
+            + Nuevo grupo
+          </button>
+        </div>
+        <div class="prompt-list" data-group-list></div>
+      </aside>
+      <section class="chat-area">
+        <header class="chat-header">
+          <div class="chat-header__row">
+            <input
+              class="chat-title-input"
+              data-chat-title
+              type="text"
+              placeholder="Título del grupo de prompts"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="chat-header__actions">
+              <button class="button button--ghost button--danger" type="button" data-action="delete-group">
+                Eliminar
+              </button>
+              <span class="save-indicator" data-save-indicator data-status="saved">
+                <span class="dot"></span>
+                <span data-save-text>Guardado</span>
+              </span>
+            </div>
+          </div>
+          <div class="chat-meta">
+            <span class="chat-meta__item" data-message-count></span>
+            <span class="chat-meta__item" data-last-saved></span>
+          </div>
+        </header>
+        <div class="chat-body" data-message-list></div>
+        <form class="add-message" data-add-message>
+          <strong>Agregar mensaje al prompt</strong>
+          <div class="add-message__row">
+            <select name="message-role" data-message-role>
+              <option value="user">Usuario</option>
+              <option value="assistant">Asistente</option>
+              <option value="system">Sistema</option>
+            </select>
+            <textarea
+              name="message-content"
+              data-message-content
+              placeholder="Describe el mensaje que deseas incorporar..."
+            ></textarea>
+          </div>
+          <div class="add-message__row" style="justify-content: flex-end;">
+            <button class="button button--primary" type="submit">Añadir mensaje</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  `;
+
+  refs.groupList = app.querySelector('[data-group-list]');
+  refs.addGroupButton = app.querySelector('[data-action="add-group"]');
+  refs.deleteGroupButton = app.querySelector('[data-action="delete-group"]');
+  refs.titleInput = app.querySelector('[data-chat-title]');
+  refs.messageList = app.querySelector('[data-message-list]');
+  refs.messageCount = app.querySelector('[data-message-count]');
+  refs.lastSaved = app.querySelector('[data-last-saved]');
+  refs.addMessageForm = app.querySelector('[data-add-message]');
+  refs.newMessageRole = app.querySelector('[data-message-role]');
+  refs.newMessageContent = app.querySelector('[data-message-content]');
+  refs.saveIndicator = app.querySelector('[data-save-indicator]');
+  refs.saveText = app.querySelector('[data-save-text]');
+
+  refs.addGroupButton.addEventListener('click', handleAddGroup);
+  refs.deleteGroupButton.addEventListener('click', handleDeleteGroup);
+  refs.titleInput.addEventListener('input', handleTitleChange);
+  refs.addMessageForm.addEventListener('submit', handleAddMessage);
+  refs.newMessageContent.addEventListener('input', (event) => {
+    autoResizeTextarea(event.target);
+  });
+}
+
+function renderSidebar() {
+  if (!refs.groupList) return;
+  refs.groupList.innerHTML = '';
+
+  if (!appState.groups.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = `
+      <h3>No hay grupos creados</h3>
+      <p>Comienza añadiendo un grupo de prompts para organizar tus ideas.</p>
+    `;
+    refs.groupList.appendChild(empty);
+    return;
+  }
+
+  appState.groups.forEach((group) => {
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = `prompt-card${group.id === appState.selectedGroupId ? ' is-active' : ''}`;
+
+    const title = document.createElement('h3');
+    title.className = 'prompt-card__title';
+    title.textContent = group.title || 'Sin título';
+    card.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'prompt-card__meta';
+
+    const messagesMeta = document.createElement('span');
+    messagesMeta.innerHTML = `${createIcon('message-circle')} ${group.messages.length} mensajes`;
+
+    const updatedMeta = document.createElement('span');
+    updatedMeta.innerHTML = `${createIcon('clock')} ${formatRelativeTime(group.updatedAt || group.createdAt)}`;
+
+    meta.appendChild(messagesMeta);
+    meta.appendChild(updatedMeta);
+    card.appendChild(meta);
+
+    card.addEventListener('click', () => {
+      appState.selectedGroupId = group.id;
+      renderSidebar();
+      renderChat();
+      scheduleSave();
+    });
+
+    refs.groupList.appendChild(card);
+  });
+}
+
+function renderChat() {
+  const group = getSelectedGroup();
+
+  if (!group) {
+    refs.titleInput.value = '';
+    refs.titleInput.disabled = true;
+    refs.deleteGroupButton.disabled = true;
+    refs.deleteGroupButton.classList.add('is-hidden');
+    refs.addMessageForm.classList.add('is-hidden');
+    refs.messageList.innerHTML = '';
+
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = `
+      <h3>Selecciona o crea un grupo</h3>
+      <p>Podrás redactar el contexto del prompt como una conversación y se guardará automáticamente.</p>
+    `;
+    refs.messageList.appendChild(empty);
+    refs.messageCount.textContent = 'Sin mensajes';
+    return;
+  }
+
+  refs.titleInput.disabled = false;
+  refs.titleInput.value = group.title;
+  refs.deleteGroupButton.disabled = false;
+  refs.deleteGroupButton.classList.remove('is-hidden');
+  refs.addMessageForm.classList.remove('is-hidden');
+
+  renderMessages(group);
+  updateMessageMeta(group);
+}
+
+function renderMessages(group) {
+  refs.messageList.innerHTML = '';
+
+  if (!group.messages.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = `
+      <h3>No hay mensajes todavía</h3>
+      <p>Añade mensajes del sistema, usuario o asistente para construir tu prompt.</p>
+    `;
+    refs.messageList.appendChild(empty);
+    return;
+  }
+
+  group.messages.forEach((message) => {
+    const messageWrapper = document.createElement('article');
+    messageWrapper.className = `message message--${message.role}`;
+
+    const header = document.createElement('div');
+    header.className = 'message__header';
+
+    const role = document.createElement('span');
+    role.className = 'message__role';
+    role.textContent = ROLE_LABELS[message.role] || 'Mensaje';
+    header.appendChild(role);
+
+    const actions = document.createElement('div');
+    actions.className = 'message__actions';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.innerHTML = `${createIcon('trash')} Eliminar`;
+    deleteButton.addEventListener('click', () => {
+      group.messages = group.messages.filter((item) => item.id !== message.id);
+      markGroupAsUpdated(group);
+      renderMessages(group);
+      updateMessageMeta(group);
+      scheduleSave();
+    });
+    actions.appendChild(deleteButton);
+
+    header.appendChild(actions);
+    messageWrapper.appendChild(header);
+
+    const textarea = document.createElement('textarea');
+    textarea.value = message.content;
+    textarea.placeholder = 'Escribe el contenido de este mensaje...';
+    textarea.addEventListener('input', (event) => {
+      message.content = event.target.value;
+      markGroupAsUpdated(group);
+      autoResizeTextarea(event.target);
+      scheduleSave();
+    });
+    autoResizeTextarea(textarea);
+    messageWrapper.appendChild(textarea);
+
+    refs.messageList.appendChild(messageWrapper);
+  });
+}
+
+function updateMessageMeta(group) {
+  const total = group.messages.length;
+  const messageLabel = total === 1 ? 'mensaje' : 'mensajes';
+  refs.messageCount.textContent = `${total} ${messageLabel} en este prompt`;
+}
+
+function handleAddGroup() {
+  const newGroup = createDefaultGroup();
+  appState.groups.unshift(newGroup);
+  appState.selectedGroupId = newGroup.id;
+  renderSidebar();
+  renderChat();
+  scheduleSave();
+}
+
+function handleDeleteGroup() {
+  const group = getSelectedGroup();
+  if (!group) return;
+
+  const confirmation = window.confirm(
+    `¿Seguro que deseas eliminar "${group.title || 'este grupo'}"? Esta acción no se puede deshacer.`
+  );
+
+  if (!confirmation) return;
+
+  appState.groups = appState.groups.filter((item) => item.id !== group.id);
+  if (appState.groups.length) {
+    appState.selectedGroupId = appState.groups[0].id;
+  } else {
+    appState.selectedGroupId = null;
+  }
+  renderSidebar();
+  renderChat();
+  scheduleSave();
+}
+
+function handleTitleChange(event) {
+  const group = getSelectedGroup();
+  if (!group) return;
+  group.title = event.target.value;
+  markGroupAsUpdated(group);
+  renderSidebar();
+  scheduleSave();
+}
+
+function handleAddMessage(event) {
+  event.preventDefault();
+  const group = getSelectedGroup();
+  if (!group) return;
+
+  const role = refs.newMessageRole.value;
+  const content = refs.newMessageContent.value.trim();
+  if (!content) {
+    refs.newMessageContent.focus();
+    return;
+  }
+
+  group.messages.push({
+    id: createId('msg'),
+    role,
+    content,
+  });
+
+  refs.newMessageContent.value = '';
+  refs.newMessageContent.style.height = '';
+  markGroupAsUpdated(group);
+  renderMessages(group);
+  updateMessageMeta(group);
+  scheduleSave();
+}
+
+function markGroupAsUpdated(group) {
+  const now = new Date().toISOString();
+  group.updatedAt = now;
+}
+
+function autoResizeTextarea(textarea) {
+  textarea.style.height = 'auto';
+  textarea.style.height = `${textarea.scrollHeight}px`;
+}
+
+function scheduleSave() {
+  updateSaveIndicator('saving');
+  if (saveTimeout) {
+    window.clearTimeout(saveTimeout);
+  }
+  saveTimeout = window.setTimeout(() => {
+    persistState();
+    saveTimeout = null;
+  }, SAVE_DELAY);
+}
+
+function persistState() {
+  try {
+    const payload = {
+      groups: appState.groups,
+      selectedGroupId: appState.selectedGroupId,
+      lastSavedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    appState.lastSavedAt = payload.lastSavedAt;
+    updateSaveIndicator('saved');
+    updateLastSavedDisplay();
+  } catch (error) {
+    console.error('No se pudo guardar el estado de PrompVerse', error);
+    updateSaveIndicator('error');
+  }
+}
+
+function loadInitialState() {
+  const fallback = createDefaultState();
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return fallback;
+    }
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed.groups)) {
+      return fallback;
+    }
+    return {
+      groups: parsed.groups.map(normalizeGroup),
+      selectedGroupId: parsed.selectedGroupId || fallback.selectedGroupId,
+      lastSavedAt: parsed.lastSavedAt || fallback.lastSavedAt,
+    };
+  } catch (error) {
+    console.warn('No se pudo cargar la información guardada, se usará el estado inicial.', error);
+    return fallback;
+  }
+}
+
+function normalizeGroup(group) {
+  return {
+    id: group.id || createId('group'),
+    title: group.title || 'Nuevo grupo',
+    createdAt: group.createdAt || new Date().toISOString(),
+    updatedAt: group.updatedAt || group.createdAt || new Date().toISOString(),
+    messages: Array.isArray(group.messages)
+      ? group.messages.map((message) => ({
+          id: message.id || createId('msg'),
+          role: ['user', 'assistant', 'system'].includes(message.role)
+            ? message.role
+            : 'user',
+          content: message.content || '',
+        }))
+      : [],
+  };
+}
+
+function createDefaultState() {
+  const groups = buildDefaultGroups();
+  return {
+    groups,
+    selectedGroupId: groups.length ? groups[0].id : null,
+    lastSavedAt: null,
+  };
+}
+
+function buildDefaultGroups() {
+  const now = new Date();
+  return [
+    {
+      id: createId('group'),
+      title: 'Estrategia de lanzamiento IA',
+      createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24).toISOString(),
+      updatedAt: new Date(now.getTime() - 1000 * 60 * 30).toISOString(),
+      messages: [
+        {
+          id: createId('msg'),
+          role: 'system',
+          content:
+            'Eres un estratega de marketing especializado en lanzamientos de productos digitales potenciados por IA. Tu objetivo es ofrecer planes accionables y medibles.',
+        },
+        {
+          id: createId('msg'),
+          role: 'user',
+          content:
+            'Estoy preparando el lanzamiento de una plataforma SaaS que recomienda prompts personalizados. Necesito un plan de lanzamiento para las primeras 4 semanas.',
+        },
+        {
+          id: createId('msg'),
+          role: 'assistant',
+          content:
+            'Claro. Primero validaré el público objetivo y canales clave. Luego diseñaré mensajes diferenciadores para cada etapa, incluyendo preventa, lanzamiento y seguimiento.',
+        },
+      ],
+    },
+    {
+      id: createId('group'),
+      title: 'Narrativas para storytelling',
+      createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 48).toISOString(),
+      updatedAt: new Date(now.getTime() - 1000 * 60 * 60 * 4).toISOString(),
+      messages: [
+        {
+          id: createId('msg'),
+          role: 'system',
+          content:
+            'Actúa como un copywriter experto en storytelling que adapta historias de producto a diferentes plataformas y públicos.',
+        },
+        {
+          id: createId('msg'),
+          role: 'user',
+          content:
+            'Necesito una narrativa aspiracional para presentar una herramienta de IA que ayuda a guionistas a iterar ideas en minutos.',
+        },
+      ],
+    },
+    {
+      id: createId('group'),
+      title: 'Prompts para UX writing',
+      createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 12).toISOString(),
+      updatedAt: new Date(now.getTime() - 1000 * 60 * 15).toISOString(),
+      messages: [
+        {
+          id: createId('msg'),
+          role: 'system',
+          content:
+            'Eres un UX writer que crea microcopys claros, empáticos y orientados a la acción para productos digitales.',
+        },
+        {
+          id: createId('msg'),
+          role: 'assistant',
+          content:
+            'Para cada microcopy, solicito tono, contexto y límite de caracteres. Devuelve tres variantes y recomendaciones de prueba A/B.',
+        },
+      ],
+    },
+  ];
+}
+
+function createDefaultGroup() {
+  const now = new Date().toISOString();
+  return {
+    id: createId('group'),
+    title: 'Nuevo grupo de prompts',
+    createdAt: now,
+    updatedAt: now,
+    messages: [
+      {
+        id: createId('msg'),
+        role: 'system',
+        content:
+          'Describe el rol de la IA, el objetivo del prompt y los entregables esperados. Añade luego mensajes de usuario y asistente para completar el contexto.',
+      },
+    ],
+  };
+}
+
+function getSelectedGroup() {
+  if (!appState.selectedGroupId) return null;
+  return appState.groups.find((group) => group.id === appState.selectedGroupId) || null;
+}
+
+function updateSaveIndicator(status) {
+  if (!refs.saveIndicator || !refs.saveText) return;
+  refs.saveIndicator.dataset.status = status;
+
+  if (status === 'saving') {
+    refs.saveText.textContent = 'Guardando cambios...';
+  } else if (status === 'saved') {
+    if (appState?.lastSavedAt) {
+      refs.saveText.textContent = `Guardado ${formatRelativeTime(appState.lastSavedAt)}`;
+    } else {
+      refs.saveText.textContent = 'Cambios guardados';
+    }
+    refs.saveIndicator.dataset.status = 'saved';
+  } else if (status === 'error') {
+    refs.saveText.textContent = 'Error al guardar';
+    refs.saveIndicator.dataset.status = 'error';
+  }
+}
+
+function updateLastSavedDisplay() {
+  if (!refs.lastSaved) return;
+  refs.lastSaved.textContent = appState.lastSavedAt
+    ? `Último guardado · ${formatExactTimestamp(appState.lastSavedAt)}`
+    : 'Sin guardados todavía';
+}
+
+function formatRelativeTime(isoDate) {
+  if (!isoDate) return 'Sin actividad';
+  const target = new Date(isoDate);
+  if (Number.isNaN(target.getTime())) return 'Sin actividad';
+  const diff = Date.now() - target.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diff < minute) return 'hace instantes';
+  if (diff < hour) {
+    const value = Math.max(1, Math.round(diff / minute));
+    return `hace ${value} min`;
+  }
+  if (diff < day) {
+    const value = Math.max(1, Math.round(diff / hour));
+    return `hace ${value} h`;
+  }
+  if (diff < day * 7) {
+    const value = Math.max(1, Math.round(diff / day));
+    return `hace ${value} d`;
+  }
+  return target.toLocaleDateString('es-ES', {
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function formatExactTimestamp(isoDate) {
+  if (!isoDate) return '';
+  const target = new Date(isoDate);
+  if (Number.isNaN(target.getTime())) return '';
+  return `${target.toLocaleDateString('es-ES', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  })} · ${target.toLocaleTimeString('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })}`;
+}
+
+function createId(prefix) {
+  if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+    return `${prefix}-${window.crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createIcon(name) {
+  if (name === 'message-circle') {
+    return `
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3h5.25M21 12a9 9 0 11-17.578 3.422c-.138.494-.206.742-.195.91.01.15.058.297.138.42.09.137.237.25.53.476C5.356 17.732 6.617 18.75 9 18.75c.684 0 1.343-.072 1.968-.208A9 9 0 0121 12z" />
+      </svg>
+    `;
+  }
+  if (name === 'clock') {
+    return `
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    `;
+  }
+  if (name === 'trash') {
+    return `
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.02-2.09 2.2v.917m7.5 0a48.667 48.667 0 00-7.5 0" />
+      </svg>
+    `;
+  }
+  return '';
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,503 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  background: radial-gradient(circle at top left, #1f2937 0%, #0b0f1a 45%, #020617 100%);
+  --surface-primary: rgba(15, 23, 42, 0.85);
+  --surface-secondary: rgba(30, 41, 59, 0.9);
+  --surface-highlight: rgba(51, 65, 85, 0.65);
+  --border-color: rgba(148, 163, 184, 0.15);
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --danger: #f87171;
+  --success: #34d399;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --shadow-soft: 0 20px 45px rgba(2, 6, 23, 0.55);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text-primary);
+  background: transparent;
+}
+
+.app-container {
+  width: min(1200px, 96vw);
+  margin: 48px auto;
+  background: rgba(2, 6, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  backdrop-filter: blur(22px);
+}
+
+.loading-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  min-height: 640px;
+}
+
+.sidebar {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.8));
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px 28px;
+}
+
+.sidebar__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.sidebar__subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.sidebar__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    border 0.2s ease;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #0f172a;
+  box-shadow: 0 10px 25px rgba(14, 165, 233, 0.4);
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(14, 165, 233, 0.45);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.button--ghost:hover {
+  color: var(--text-primary);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.button--danger {
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.button--danger:hover {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.prompt-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.prompt-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.prompt-list::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+}
+
+.prompt-card {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.7));
+  border: 1px solid transparent;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.prompt-card:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 3px;
+}
+
+.prompt-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(14, 165, 233, 0.4);
+  box-shadow: 0 14px 35px rgba(14, 165, 233, 0.2);
+}
+
+.prompt-card.is-active {
+  border-color: rgba(14, 165, 233, 0.6);
+  box-shadow: 0 20px 40px rgba(14, 165, 233, 0.25);
+}
+
+.prompt-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.prompt-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.prompt-card__meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.prompt-card__meta svg {
+  width: 16px;
+  height: 16px;
+  opacity: 0.6;
+}
+
+.chat-area {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(200deg, rgba(15, 23, 42, 0.7), rgba(2, 6, 23, 0.8));
+  padding: 32px;
+  gap: 24px;
+}
+
+.chat-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.chat-header__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chat-header__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.chat-title-input {
+  flex: 1 1 280px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 1.5rem;
+  font-weight: 600;
+  padding: 14px 18px;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-title-input:focus {
+  border-color: rgba(14, 165, 233, 0.75);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.2);
+}
+
+.chat-meta {
+  display: flex;
+  gap: 16px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.chat-meta__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chat-meta svg {
+  width: 18px;
+  height: 18px;
+}
+
+.chat-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.chat-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-body::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 640px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.7);
+  position: relative;
+}
+
+.message--user {
+  margin-left: auto;
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.15), rgba(30, 58, 138, 0.4));
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.message--assistant {
+  margin-right: auto;
+}
+
+.message--system {
+  margin: 0 auto;
+  border-style: dashed;
+}
+
+.message__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.message__role {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.message textarea {
+  width: 100%;
+  background: transparent;
+  color: var(--text-primary);
+  border: none;
+  resize: none;
+  font-size: 1rem;
+  line-height: 1.6;
+  font-family: inherit;
+  padding: 0;
+  outline: none;
+}
+
+.message textarea::placeholder {
+  color: rgba(148, 163, 184, 0.4);
+}
+
+.message__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.message__actions button {
+  background: transparent;
+  border: none;
+  color: rgba(148, 163, 184, 0.6);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  transition: color 0.2s ease;
+}
+
+.message__actions button:hover {
+  color: var(--text-primary);
+}
+
+.add-message {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.add-message__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.add-message select {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  padding: 10px 14px;
+  min-width: 160px;
+  font-size: 0.95rem;
+}
+
+.add-message textarea {
+  flex: 1 1 320px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  padding: 12px 16px;
+  resize: vertical;
+  min-height: 120px;
+  font-size: 1rem;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.add-message textarea:focus,
+.add-message select:focus {
+  border-color: rgba(14, 165, 233, 0.6);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.2);
+}
+
+.empty-state {
+  margin: auto;
+  text-align: center;
+  color: var(--text-secondary);
+  max-width: 320px;
+}
+
+.empty-state h3 {
+  margin-bottom: 8px;
+  color: var(--text-primary);
+}
+
+.save-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.save-indicator .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  display: inline-block;
+}
+
+.save-indicator[data-status='saving'] {
+  color: var(--accent);
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+.save-indicator[data-status='saved'] {
+  color: var(--success);
+  border-color: rgba(52, 211, 153, 0.4);
+}
+
+.save-indicator[data-status='error'] {
+  color: var(--danger);
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+@media (max-width: 980px) {
+  .app-container {
+    width: 100%;
+    margin: 0;
+    border-radius: 0;
+    min-height: 100vh;
+  }
+
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+}
+
+@media (max-width: 640px) {
+  .chat-header__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .add-message__row {
+    flex-direction: column;
+  }
+
+  .chat-area {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static PrompVerse dashboard that organizes prompt grupos by temática and displays each as a chat-like editor
- implement autosave to localStorage for titles and messages plus controls to add, edit or delete grupos y mensajes
- style the interface with a dark modern theme and document usage in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46600984c832fb609c71dd3234789